### PR TITLE
fix: remove warning about "forwardRef" of component Checkbox

### DIFF
--- a/src/form/checkbox.tsx
+++ b/src/form/checkbox.tsx
@@ -5,7 +5,7 @@ export interface CheckboxProps<T = HTMLInputElement>
 	extends React.HTMLProps<T> {}
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-	({ children, ...props }) => {
+	({ children, ...props }, ref) => {
 		const wrapperClassNames = classnames("checkbox", props.className);
 
 		return (
@@ -14,7 +14,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 				// @ts-ignore
 				disabled={props.disabled}
 			>
-				<input type="checkbox" {...props} />
+				<input type="checkbox" {...props} ref={ref} />
 				{children}
 			</label>
 		);


### PR DESCRIPTION
Fixed a bug due to which this warning was displayed:
```
Warning: forwardRef render functions accept exactly two parameters: props and ref. 
Did you forget to use the ref parameter?
```
